### PR TITLE
Update fsb version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
   <properties>
     <java.version>11</java.version>
     <log4j2.version>2.17.0</log4j2.version>
-    <folio-spring-base-version>3.0.1</folio-spring-base-version>
+    <folio-spring-base-version>4.0.0</folio-spring-base-version>
     <edge-api-utils-version>1.1.1</edge-api-utils-version>
     <wiremock-version>2.27.2</wiremock-version>
     <!--Exclude this packages from sonar, as it contains only interfaces and entities-->

--- a/pom.xml
+++ b/pom.xml
@@ -40,12 +40,6 @@
       <groupId>org.folio</groupId>
       <artifactId>folio-spring-base</artifactId>
       <version>${folio-spring-base-version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.liquibase</groupId>
-          <artifactId>liquibase-core</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
 
     <dependency>


### PR DESCRIPTION

## Purpose
Update folio-spring-base version to the latest v4.0.0

Removed exclusion of liquibase, because we are not able to create some beans from fsb without it(we can disable liquibase in app.properties and exclude DataSourceAutoConfiguration if we don`t need DB).