### PR TITLE
EDGCMNSPR-14 update version to the next major

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
   <groupId>org.folio</groupId>
   <artifactId>edge-common-spring</artifactId>
-  <version>1.3.0-SNAPSHOT</version>
+  <version>2.0.0-SNAPSHOT</version>
   <name>edge-common-spring</name>
   <description>A shared library/framework for edge APIs for spring way modules</description>
   <packaging>jar</packaging>


### PR DESCRIPTION

## Purpose
https://issues.folio.org/browse/EDGCMNSPR-14

## Approach
Modules that use edge-common-spring 2.0.0 will need to make some code changes after upgrading of edge-common-spring to 4.0.0 version, so the major version increased
