### PR TITLE
Release v2.0.0 - Update news

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## 08/04/2022 v2.0.0 - Released
+* [EDGCMNSPR-14](https://issues.folio.org/browse/EDGCMNSPR-14) Upgrade folio-spring-base to 4.0.0
+
 ## 22/02/2022 v1.2.0 - Released
 * [EDGCMNSPR-9](https://issues.folio.org/browse/EDGCMNSPR-9) Upgrade to the folio spring base v.3.0.1
 

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
   <groupId>org.folio</groupId>
   <artifactId>edge-common-spring</artifactId>
-  <version>2.0.0</version>
+  <version>2.0.1-SNAPSHOT</version>
   <name>edge-common-spring</name>
   <description>A shared library/framework for edge APIs for spring way modules</description>
   <packaging>jar</packaging>
@@ -200,7 +200,7 @@
     <url>https://github.com/folio-org/${project.artifactId}</url>
     <connection>scm:git:git://github.com/folio-org/${project.artifactId}.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/${project.artifactId}.git</developerConnection>
-    <tag>v2.0.0</tag>
+    <tag>HEAD</tag>
   </scm>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
   <groupId>org.folio</groupId>
   <artifactId>edge-common-spring</artifactId>
-  <version>2.0.0-SNAPSHOT</version>
+  <version>2.0.0</version>
   <name>edge-common-spring</name>
   <description>A shared library/framework for edge APIs for spring way modules</description>
   <packaging>jar</packaging>
@@ -200,7 +200,7 @@
     <url>https://github.com/folio-org/${project.artifactId}</url>
     <connection>scm:git:git://github.com/folio-org/${project.artifactId}.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/${project.artifactId}.git</developerConnection>
-    <tag>HEAD</tag>
+    <tag>v2.0.0</tag>
   </scm>
 
 </project>


### PR DESCRIPTION


## Purpose
https://issues.folio.org/browse/EDGCMNSPR-15

## Approach
Release v2.0.0 of edge-common-spring. In this version, we have upgraded the version of folio-spring-base to 4.0.0. Using it will require some code changes (for example contract of tenant API changed), so the major version increase.