### PR TITLE
EDGCMNSPR-43: Spring Boot 3.1.6, folio-spring-* 7.2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.1.3</version>
+    <version>3.1.6</version>
     <relativePath />
   </parent>
 
@@ -24,8 +24,7 @@
 
   <properties>
     <java.version>17</java.version>
-    <folio-spring-base-version>7.2.0</folio-spring-base-version>
-    <folio-spring-system-user-version>7.2.0</folio-spring-system-user-version>
+    <folio-spring-version>7.2.2</folio-spring-version>  <!-- also update spring-boot-starter-parent version above -->
     <versions-maven-plugin-version>2.16.0</versions-maven-plugin-version>
     <maven-enforcer-plugin-version>3.4.0</maven-enforcer-plugin-version>
     <build-helper-maven-plugin-version>3.4.0</build-helper-maven-plugin-version>
@@ -46,12 +45,12 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>folio-spring-base</artifactId>
-      <version>${folio-spring-base-version}</version>
+      <version>${folio-spring-version}</version>
     </dependency>
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>folio-spring-system-user</artifactId>
-      <version>${folio-spring-system-user-version}</version>
+      <version>${folio-spring-version}</version>
     </dependency>
     <dependency>
       <groupId>org.folio</groupId>


### PR DESCRIPTION
https://issues.folio.org/browse/EDGCMNSPR-43

Upgrade spring-boot-starter-parent from 3.1.3 to 3.1.6.

The Spring Boot upgrade indirectly upgrades tomcat-embed-core from 10.1.12 to 10.1.16 fixing Denial of Service (DoS), Access Restriction Bypass, Improper Input Validation, and Incomplete Cleanup:
https://nvd.nist.gov/vuln/detail/CVE-2023-44487
https://nvd.nist.gov/vuln/detail/CVE-2023-41080
https://nvd.nist.gov/vuln/detail/CVE-2023-45648
https://nvd.nist.gov/vuln/detail/CVE-2023-42795

Upgrade folio-spring-* from 7.2.0 to 7.2.2.

The folio-spring-* upgrade indirectly upgrades bcprov-jdk15on:1.69 to bcprov-jdk18on:jar:1.73 fixing out of memory (OOM) denial of service (DoS):
https://github.com/bcgit/bc-java/wiki/CVE-2023-33202