### PR TITLE
EDGCMNSPR-47: Spring Boot 3.2, folio-spring 8.1, edge-api-utils 1.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.1.6</version>
+    <version>3.2.3</version>
     <relativePath />
   </parent>
 
@@ -24,16 +24,15 @@
 
   <properties>
     <java.version>17</java.version>
-    <folio-spring-version>7.2.2</folio-spring-version>  <!-- also update spring-boot-starter-parent version above -->
-    <versions-maven-plugin-version>2.16.0</versions-maven-plugin-version>
-    <maven-enforcer-plugin-version>3.4.0</maven-enforcer-plugin-version>
-    <build-helper-maven-plugin-version>3.4.0</build-helper-maven-plugin-version>
+    <folio-spring-version>8.1.0</folio-spring-version>  <!-- also update spring-boot-starter-parent version above -->
+    <versions-maven-plugin-version>2.16.2</versions-maven-plugin-version>
+    <maven-enforcer-plugin-version>3.4.1</maven-enforcer-plugin-version>
+    <build-helper-maven-plugin-version>3.5.0</build-helper-maven-plugin-version>
     <maven-release-plugin-version>3.0.1</maven-release-plugin-version>
     <maven-source-plugin-version>3.3.0</maven-source-plugin-version>
-    <maven-javadoc-plugin-version>3.5.0</maven-javadoc-plugin-version>
+    <maven-javadoc-plugin-version>3.6.3</maven-javadoc-plugin-version>
     <maven-deploy-plugin-version>3.1.1</maven-deploy-plugin-version>
-    <edge-api-utils-version>1.3.0</edge-api-utils-version>
-    <mockito-version>5.2.0</mockito-version>
+    <edge-api-utils-version>1.4.0</edge-api-utils-version>
     <!--Exclude this packages from sonar, as it contains only interfaces and entities-->
     <sonar.exclusions>
       src/main/java/org/folio/edgecommonspring/domain/**,
@@ -99,16 +98,7 @@
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-codec-http</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-inline</artifactId>
-      <version>${mockito-version}</version>
-      <scope>test</scope>
-    </dependency>
+
   </dependencies>
 
   <build>


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/EDGCMNSPR-47

For Quesnelia upgrade all dependencies.

Most notable:

Upgrade Spring Boot from 3.1.6 to 3.2.3.

Upgrade folio-spring-support from 7.2.2 to 8.1.0.

Upgrade edge-api-utils from 1.3.0 to 1.4.0.