### PR TITLE
EDGCMNSPR-53: Spring Boot 3.2.6, bcprov-jdk18on 1.78 fixing vulns

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.2.3</version>
+    <version>3.2.6</version>
     <relativePath />
   </parent>
 
@@ -24,7 +24,7 @@
 
   <properties>
     <java.version>17</java.version>
-    <folio-spring-version>8.1.0</folio-spring-version>  <!-- also update spring-boot-starter-parent version above -->
+    <folio-spring-version>8.1.2</folio-spring-version>  <!-- also update spring-boot-starter-parent version above -->
     <versions-maven-plugin-version>2.16.2</versions-maven-plugin-version>
     <maven-enforcer-plugin-version>3.4.1</maven-enforcer-plugin-version>
     <build-helper-maven-plugin-version>3.5.0</build-helper-maven-plugin-version>


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/EDGCMNSPR-53

Upgrade Spring Boot from 3.2.3 to 3.2.6.

Upgrade folio-spring from 8.1.0 to 8.1.1.

Upgrade spring-security-rsa from 1.1.1 to 1.1.3.

The Spring Boot upgrade indirectly upgrades spring-web from 6.1.4 to 6.1.8 fixing UriComponentsBuilder Open Redirect:

https://spring.io/security/cve-2024-22259
https://spring.io/security/cve-2024-22262

The Spring Boot upgrade indirectly upgrades netty-codec-http from 4.1.107.Final to 4.1.110.Final fixing form POST OOM:

https://github.com/netty/netty/security/advisories/GHSA-5jpm-x58v-624v = CVE-2024-29025

The folio-spring-version upgrade and the spring-security-rsa indirectly upgrade bcprov-jdk18on from 1.74 to 1.78 fixing multiple vulnerabilities:

* https://www.cve.org/CVERecord?id=CVE-2024-30172  Ed25519 Infinitive Loop
* https://www.cve.org/CVERecord?id=CVE-2024-30171  RSA side-channel attack
* https://security.snyk.io/vuln/SNYK-JAVA-ORGBOUNCYCASTLE-6277381  PKCS#1 1.5 and OAEP side-channel attack
* https://www.cve.org/CVERecord?id=CVE-2024-29857  ECCurve excessive CPU consumption

The bcprov-jdk18on vulnerabilities affect TLS.