### PR TITLE
EDGCMNSPR-57: Upgrade dependencies for Ramsons fixing vulns

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.2.6</version>
+    <version>3.3.7</version>
     <relativePath />
   </parent>
 
@@ -24,7 +24,7 @@
 
   <properties>
     <java.version>17</java.version>
-    <folio-spring-version>8.1.2</folio-spring-version>  <!-- also update spring-boot-starter-parent version above -->
+    <folio-spring-version>8.2.2</folio-spring-version>  <!-- also update spring-boot-starter-parent version above -->
     <versions-maven-plugin-version>2.16.2</versions-maven-plugin-version>
     <maven-enforcer-plugin-version>3.4.1</maven-enforcer-plugin-version>
     <build-helper-maven-plugin-version>3.5.0</build-helper-maven-plugin-version>
@@ -32,13 +32,13 @@
     <maven-source-plugin-version>3.3.0</maven-source-plugin-version>
     <maven-javadoc-plugin-version>3.6.3</maven-javadoc-plugin-version>
     <maven-deploy-plugin-version>3.1.1</maven-deploy-plugin-version>
-    <edge-api-utils-version>1.4.3</edge-api-utils-version>
+    <edge-api-utils-version>1.5.0</edge-api-utils-version>
     <!--Exclude this packages from sonar, as it contains only interfaces and entities-->
     <sonar.exclusions>
       src/main/java/org/folio/edgecommonspring/domain/**,
       src/main/java/org/folio/edgecommonspring/client/EdgeFeignClientProperties.java
     </sonar.exclusions>
-    <folio-backend-common.version>1.5.6</folio-backend-common.version>
+    <folio-backend-common.version>2.0.0</folio-backend-common.version>
     <commons-lang3.version>3.17.0</commons-lang3.version>
   </properties>
 


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/EDGCMNSPR-57

## Purpose
Fix security vulnerabilities.
Upgrade to Ramson dependencies.
Spring Boot 3.2 has been [out of support since 2024-11-23](https://spring.io/projects/spring-boot#support).

## Approach
Upgrade Spring Boot from 3.2.6 to 3.3.7.

Upgrade folio-spring-* from 8.1.2 to 8.2.2.

Upgrade edge-api-utils from 1.4.3 to 1.5.0.

Upgrade folio-backend-common from 1.5.6 to 2.0.0.

The upgrades fix these security vulnerabilities:

* https://www.cve.org/CVERecord?id=CVE-2024-38286 tomcat-embed-core OutOfMemoryError in TLS 1.3
* https://www.cve.org/CVERecord?id=CVE-2024-34750 tomcat-embed-core HTTP/2 stream out-of-memory
* https://www.cve.org/CVERecord?id=CVE-2024-47554 commons-io excessive CPU resources in XmlStreamReader

## Pre-Merge Checklist:
 Before merging this PR, please go through the following list and take appropriate actions.

 - Does this PR meet or exceed the expected quality standards?
   - [x] Code coverage on new code is 80% or greater
   - [x] Duplications on new code is 3% or less
   - [x] There are no major code smells or security issues
 - Does this introduce breaking changes?
   - [x] There are no breaking changes in this PR.
