### PR TITLE
EDGCMNSPR-65: Add optional RestClient customizer for edge module

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@ This is the Sunflower release with updates of dependencies and Java.
 
 * [EDGCMNSPR-59](https://folio-org.atlassian.net/browse/EDGCMNSPR-59) Migrate to Java 21; Bump to Spring Boot 3.4.3
 * [#61](https://github.com/folio-org/edge-common-spring/pull/61) Bump up edge-api-utils to 1.6.0
+* [EDGCMNSPR-65](https://folio-org.atlassian.net/browse/EDGCMNSPR-65) Add optional RestClient customizer for edge module
 
 ## 27/01/2025 v2.5.0 - Released
 This release contains dependencies updating.

--- a/src/main/java/org/folio/edgecommonspring/config/EdgeServiceClientConfiguration.java
+++ b/src/main/java/org/folio/edgecommonspring/config/EdgeServiceClientConfiguration.java
@@ -29,6 +29,9 @@ import org.springframework.web.client.RestClient;
 import org.springframework.web.client.support.RestClientAdapter;
 import org.springframework.web.service.invoker.HttpServiceProxyFactory;
 
+import java.util.Optional;
+import java.util.function.UnaryOperator;
+
 import static org.apache.commons.lang3.ObjectUtils.getIfNull;
 import static org.folio.common.utils.tls.FeignClientTlsUtils.buildSslContext;
 import static org.folio.common.utils.tls.Utils.IS_HOSTNAME_VERIFICATION_DISABLED;
@@ -82,9 +85,14 @@ public class EdgeServiceClientConfiguration {
 
   @Bean
   public HttpServiceProxyFactory edgeHttpServiceProxyFactory(
-    @Qualifier("edgeExchangeRestClientBuilder") RestClient.Builder exchangeRestClient) {
+    @Qualifier("edgeExchangeRestClientBuilder") RestClient.Builder exchangeRestClient,
+    @Qualifier("edgeRestClientCustomizer") Optional<UnaryOperator<RestClient.Builder>> restClientCustomizer) {
+    var restClient = restClientCustomizer
+      .map(customizer -> customizer.apply(exchangeRestClient).build())
+      .orElseGet(exchangeRestClient::build);
+
     return HttpServiceProxyFactory
-      .builderFor(RestClientAdapter.create(exchangeRestClient.build()))
+      .builderFor(RestClientAdapter.create(restClient))
       .build();
   }
 

--- a/src/test/java/org/folio/edgecommonspring/config/EdgeServiceClientConfigurationTest.java
+++ b/src/test/java/org/folio/edgecommonspring/config/EdgeServiceClientConfigurationTest.java
@@ -17,6 +17,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.web.client.RestClient;
 
+import java.util.Optional;
+import java.util.function.UnaryOperator;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.atLeastOnce;
@@ -127,7 +130,21 @@ class EdgeServiceClientConfigurationTest {
   @Test
   void shouldCreateEdgeHttpServiceProxyFactory() {
     var restClientBuilder = RestClient.builder();
-    var factory = configuration.edgeHttpServiceProxyFactory(restClientBuilder);
+    var factory = configuration.edgeHttpServiceProxyFactory(restClientBuilder, Optional.empty());
+
+    assertThat(factory).isNotNull();
+  }
+
+  @Test
+  void shouldCreateEdgeHttpServiceProxyFactoryWithCustomizer() {
+    var restClientBuilder = RestClient.builder();
+    UnaryOperator<RestClient.Builder> customizer = builder ->
+      builder.baseUrl("http://custom-url");
+
+    var factory = configuration.edgeHttpServiceProxyFactory(
+      restClientBuilder,
+      Optional.of(customizer)
+    );
 
     assertThat(factory).isNotNull();
   }


### PR DESCRIPTION
[EDGCMNSPR-65](https://folio-org.atlassian.net/browse/EDGCMNSPR-65)

## Purpose
Allow edge modules to customize RestClient behavior, such as exception handling, by providing an optional `edgeRestClientCustomizer` bean.

## Approach
Added support for optional `UnaryOperator<RestClient.Builder>` bean in edge-common-spring. If provided, it will be applied to the RestClient builder before creating the HttpServiceProxyFactory. This allows edge modules to define their own RestClient configuration, such as custom status handlers for exception handling.

### TODOS and Open Questions
 - [x] Use GitHub checklists. When solved, check the box and explain the answer.

## Pre-Merge Checklist:
 Before merging this PR, please go through the following list and take appropriate actions.

 - Does this PR meet or exceed the expected quality standards?
   - [x] Code coverage on new code is 80% or greater
   - [x] Duplications on new code is 3% or less
   - [x] There are no major code smells or security issues
 - Does this introduce breaking changes?
   - [ ] Were any API paths or methods changed, added or removed?
   - [ ] Were there any schema changes?
   - [ ] Did any of the interface versions change?
   - [ ] Were permissions changed, added, or removed?
   - [ ] Are there new interface dependencies?
   - [ ] There are no breaking changes in this PR.

 If there are breaking changes, please **STOP** and consider the following:

 - What other modules will these changes impact?
 - Do JIRAs exist to update the impacted modules?
   - [ ] If not, please create them
   - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
   - [ ] Do they have all they appropriate links to blocked/related issues?
 - Are the JIRAs under active development?
   - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
 - Do PRs exist for these changes?
   - [ ] If so, have they been approved?

