### PR TITLE
chore(EDGCMNSPR-66): Remove deprecated folio.okapiUrl property

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,7 +9,3 @@ spring:
     openfeign:
       okhttp:
         enabled: true
-
-# Dokapi_url is deprecated. Please use folio.client.okapiUrl instead
-folio:
-  okapi-url: ${okapi_url:http://okapi:9130}


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/EDGCMNSPR-66

## Purpose
 Remove deprecated folio.okapiUrl property from application.yaml. Keeping this property requires maintaining the old okapi_url environment variable for edge modules.

## Approach
During the migration of edge-inventory to Spring Boot 4 it appeared that because of **folio.okapiUrl**  property  we need to be sure that **okapi_url** env variable present. Otherwise, SystemUserService inject default value **"http://okapi:9130"** to the Folio context. It breaks the logic of EdgeUrlRequestInterceptor during authn request.

## Pre-Merge Checklist:
 Before merging this PR, please go through the following list and take appropriate actions.

 - Does this PR meet or exceed the expected quality standards?
   - [x] Code coverage on new code is 80% or greater
   - [x] Duplications on new code is 3% or less
   - [x] There are no major code smells or security issues
 - Does this introduce breaking changes?
   - [ ] Were any API paths or methods changed, added or removed?
   - [ ] Were there any schema changes?
   - [ ] Did any of the interface versions change?
   - [ ] Were permissions changed, added, or removed?
   - [ ] Are there new interface dependencies?
   - [x] There are no breaking changes in this PR.
